### PR TITLE
bug(applications): the meaning of 'app' and 'application' changed

### DIFF
--- a/jx_create_quickstart_android_quickstart.go
+++ b/jx_create_quickstart_android_quickstart.go
@@ -7,5 +7,5 @@ import (
 //var _ = CreateQuickstartTests("android-quickstart")
 
 var _ = PDescribe("quickstart android-quickstart", func() {
-	PIt("Creates an app", func() {})
+	PIt("Creates an application", func() {})
 })

--- a/jx_create_quickstart_angular_io_quickstart.go
+++ b/jx_create_quickstart_angular_io_quickstart.go
@@ -7,5 +7,5 @@ import (
 //var _ = CreateQuickstartTests("angular-io-quickstart")
 
 var _ = PDescribe("quickstart angular-io-quickstart", func() {
-	PIt("Creates an app", func() {})
+	PIt("Creates an application", func() {})
 })

--- a/jx_create_quickstart_aspnet_app.go
+++ b/jx_create_quickstart_aspnet_app.go
@@ -7,5 +7,5 @@ import (
 //var _ = CreateQuickstartTests("aspnet-app")
 
 var _ = PDescribe("quickstart aspnet-app", func() {
-	PIt("Creates an app", func() {})
+	PIt("Creates an application", func() {})
 })

--- a/jx_create_quickstart_open_liberty.go
+++ b/jx_create_quickstart_open_liberty.go
@@ -7,5 +7,5 @@ import (
 //var _ = CreateQuickstartTests("open-liberty")
 
 var _ = PDescribe("quickstart open-liberty", func() {
-	PIt("Creates an app", func() {})
+	PIt("Creates an application", func() {})
 })

--- a/jx_create_quickstart_spring_boot_http_gradle.go
+++ b/jx_create_quickstart_spring_boot_http_gradle.go
@@ -7,5 +7,5 @@ import (
 //var _ = CreateQuickstartTests("spring-boot-http-gradle")
 
 var _ = PDescribe("quickstart spring-boot-http-gradle", func() {
-	PIt("Creates an app", func() {})
+	PIt("Creates an application", func() {})
 })

--- a/jx_create_quickstart_spring_boot_rest_prometheus.go
+++ b/jx_create_quickstart_spring_boot_rest_prometheus.go
@@ -7,5 +7,5 @@ import (
 //var _ = CreateQuickstartTests("spring-boot-rest-prometheus")
 
 var _ = PDescribe("quickstart spring-boot-rest-prometheus", func() {
-	PIt("Creates an app", func() {})
+	PIt("Creates an application", func() {})
 })

--- a/jx_create_quickstart_vertx_rest_prometheus.go
+++ b/jx_create_quickstart_vertx_rest_prometheus.go
@@ -7,5 +7,5 @@ import (
 //var _ = CreateQuickstartTests("vertx-rest-prometheus")
 
 var _ = PDescribe("quickstart vertx-rest-prometheus", func() {
-	PIt("Creates an app", func() {})
+	PIt("Creates an application", func() {})
 })

--- a/jx_create_spring.go
+++ b/jx_create_spring.go
@@ -20,9 +20,9 @@ var _ = Describe("create spring\n", func() {
 
 	BeforeEach(func() {
 		T = Test{
-			AppName: TempDirPrefix + "spring-" + strconv.FormatInt(GinkgoRandomSeed(), 10),
-			WorkDir: WorkDir,
-			Factory: cmd.NewFactory(),
+			ApplicationName: TempDirPrefix + "spring-" + strconv.FormatInt(GinkgoRandomSeed(), 10),
+			WorkDir:         WorkDir,
+			Factory:         cmd.NewFactory(),
 		}
 		T.GitProviderURL()
 	})
@@ -31,7 +31,7 @@ var _ = Describe("create spring\n", func() {
 		Context("when running jx create spring", func() {
 			It("creates a spring application and promotes it to staging\n", func() {
 				c := "jx"
-				args := []string{"create", "spring", "-b", "--org", T.GetGitOrganisation(), "--artifact", T.AppName, "--name", T.AppName, "-d", "web", "-d", "actuator"}
+				args := []string{"create", "spring", "-b", "--org", T.GetGitOrganisation(), "--artifact", T.ApplicationName, "--name", T.ApplicationName, "-d", "web", "-d", "actuator"}
 
 				gitProviderUrl, err := T.GitProviderURL()
 				Expect(err).NotTo(HaveOccurred())
@@ -57,10 +57,10 @@ var _ = Describe("create spring\n", func() {
 					T.CreatePullRequestAndGetPreviewEnvironment(404)
 				}
 
-				if T.DeleteApps() {
-					By("deletes the app")
-					fullAppName := T.GetGitOrganisation() + "/" + T.AppName
-					args = []string{"delete", "app", "-b", fullAppName}
+				if T.DeleteApplications() {
+					By("deletes the application")
+					fullApplicationName := T.GetGitOrganisation() + "/" + T.ApplicationName
+					args = []string{"delete", "application", "-b", fullApplicationName}
 					command = exec.Command(c, args...)
 					command.Dir = T.WorkDir
 					session, err = gexec.Start(command, GinkgoWriter, GinkgoWriter)
@@ -71,7 +71,7 @@ var _ = Describe("create spring\n", func() {
 
 				if T.DeleteRepos() {
 					By("deletes the repo")
-					args = []string{"delete", "repo", "-b", "--github", "-o", T.GetGitOrganisation(), "-n", T.AppName}
+					args = []string{"delete", "repo", "-b", "--github", "-o", T.GetGitOrganisation(), "-n", T.ApplicationName}
 					command = exec.Command(c, args...)
 					command.Dir = T.WorkDir
 					session, err = gexec.Start(command, GinkgoWriter, GinkgoWriter)

--- a/jx_import.go
+++ b/jx_import.go
@@ -21,17 +21,17 @@ var _ = Describe("import\n", func() {
 
 	BeforeEach(func() {
 		T = Test{
-			AppName: TempDirPrefix + "import-" + strconv.FormatInt(GinkgoRandomSeed(), 10),
-			WorkDir: WorkDir,
-			Factory: cmd.NewFactory(),
+			ApplicationName: TempDirPrefix + "import-" + strconv.FormatInt(GinkgoRandomSeed(), 10),
+			WorkDir:         WorkDir,
+			Factory:         cmd.NewFactory(),
 		}
 		T.GitProviderURL()
 	})
 
 	Describe("Given valid parameters", func() {
 		Context("when running import", func() {
-			It("creates an app from the specified folder and promotes it to staging\n", func() {
-				dest_dir := T.WorkDir + "/" + T.AppName
+			It("creates an application from the specified folder and promotes it to staging\n", func() {
+				dest_dir := T.WorkDir + "/" + T.ApplicationName
 
 				_, err := git.PlainClone(dest_dir, false, &git.CloneOptions{
 					URL:      "https://github.com/jenkins-x-quickstarts/spring-boot-watch-pipeline-activity.git",
@@ -40,7 +40,7 @@ var _ = Describe("import\n", func() {
 				Expect(err).NotTo(HaveOccurred())
 				os.RemoveAll(dest_dir + "/.git")
 				Expect(dest_dir + "/.git").ToNot(BeADirectory())
-				err = utils.ReplaceElement(filepath.Join(dest_dir, "pom.xml"), "artifactId", T.AppName, 1)
+				err = utils.ReplaceElement(filepath.Join(dest_dir, "pom.xml"), "artifactId", T.ApplicationName, 1)
 				Expect(err).NotTo(HaveOccurred())
 
 				c := "jx"
@@ -55,10 +55,10 @@ var _ = Describe("import\n", func() {
 				Eventually(session).Should(gexec.Exit(0))
 				T.TheApplicationShouldBeBuiltAndPromotedViaCICD(200)
 
-				if T.DeleteApps() {
-					By("deletes the app")
-					fullAppName := T.GetGitOrganisation() + "/" + T.AppName
-					args = []string{"delete", "app", "-b", fullAppName}
+				if T.DeleteApplications() {
+					By("deletes the application")
+					fullApplicationName := T.GetGitOrganisation() + "/" + T.ApplicationName
+					args = []string{"delete", "application", "-b", fullApplicationName}
 					command = exec.Command(c, args...)
 					command.Dir = dest_dir
 					session, err = gexec.Start(command, GinkgoWriter, GinkgoWriter)
@@ -69,7 +69,7 @@ var _ = Describe("import\n", func() {
 
 				if T.DeleteRepos() {
 					By("deletes the repo")
-					args = []string{"delete", "repo", "-b", "-g", gitProviderUrl, "-o", T.GetGitOrganisation(), "-n", T.AppName}
+					args = []string{"delete", "repo", "-b", "-g", gitProviderUrl, "-o", T.GetGitOrganisation(), "-n", T.ApplicationName}
 					command = exec.Command(c, args...)
 					command.Dir = dest_dir
 					session, err = gexec.Start(command, GinkgoWriter, GinkgoWriter)

--- a/main.go
+++ b/main.go
@@ -34,11 +34,11 @@ var (
 
 // Test is the standard testing object
 type Test struct {
-	Factory      cmd.Factory
-	Interactive  bool
-	WorkDir      string
-	AppName      string
-	Organisation string
+	Factory         cmd.Factory
+	Interactive     bool
+	WorkDir         string
+	ApplicationName string
+	Organisation    string
 }
 
 // GetGitOrganisation Gets the current git organisation/user
@@ -73,7 +73,7 @@ func (t *Test) GitProviderURL() (string, error) {
 	return servers[0].URL, nil
 }
 
-// TheApplicationIsRunningInStaging lets assert that the app is deployed into the first automatic staging environment
+// TheApplicationIsRunningInStaging lets assert that the application is deployed into the first automatic staging environment
 func (t *Test) TheApplicationIsRunningInStaging(statusCode int) {
 	u := ""
 	key := "staging"
@@ -92,18 +92,18 @@ func (t *Test) TheApplicationIsRunningInStaging(statusCode int) {
 			return err
 		}
 
-		appName := t.GetAppName()
+		applicationName := t.GetApplicationName()
 		if len(o.Results.Applications) == 0 {
 			return fmt.Errorf("No applications found")
 		}
-		utils.LogInfof("application name %s application map %#v\n", appName, o.Results.Applications)
+		utils.LogInfof("application name %s application map %#v\n", applicationName, o.Results.Applications)
 
-		appEnvInfo := o.Results.Applications[appName]
-		appName2 := "jx-" + appName
+		appEnvInfo := o.Results.Applications[applicationName]
+		applicationName2 := "jx-" + applicationName
 		if appEnvInfo == nil {
-			appEnvInfo = o.Results.Applications[appName2]
+			appEnvInfo = o.Results.Applications[applicationName2]
 		}
-		Expect(appEnvInfo).ShouldNot(BeNil(), "no AppEnvInfo for app %s or %s", appName, appName2)
+		Expect(appEnvInfo).ShouldNot(BeNil(), "no AppEnvInfo for application %s or %s", applicationName, applicationName2)
 
 		if appEnvInfo != nil {
 			m := appEnvInfo[key]
@@ -132,9 +132,9 @@ func (t *Test) TheApplicationIsRunningInStaging(statusCode int) {
 // TheApplicationShouldBeBuiltAndPromotedViaCICD asserts that the project
 // should be created in Jenkins and that the build should complete successfully
 func (t *Test) TheApplicationShouldBeBuiltAndPromotedViaCICD(statusCode int) {
-	appName := t.GetAppName()
+	applicationName := t.GetApplicationName()
 	owner := t.GetGitOrganisation()
-	jobName := owner + "/" + appName + "/master"
+	jobName := owner + "/" + applicationName + "/master"
 
 	t.ThereShouldBeAJobThatCompletesSuccessfully(jobName, 20*time.Minute)
 
@@ -144,8 +144,8 @@ func (t *Test) TheApplicationShouldBeBuiltAndPromotedViaCICD(statusCode int) {
 // CreatePullRequestAndGetPreviewEnvironment asserts that a pull request can be created
 // on the application and the PR goes green and a preview environment is available
 func (t *Test) CreatePullRequestAndGetPreviewEnvironment(statusCode int) error {
-	appName := t.GetAppName()
-	workDir := filepath.Join(t.WorkDir, appName)
+	applicationName := t.GetApplicationName()
+	workDir := filepath.Join(t.WorkDir, applicationName)
 	owner := t.GetGitOrganisation()
 
 	utils.LogInfof("Creating a Pull Request in folder: %s\n", workDir)
@@ -189,7 +189,7 @@ func (t *Test) CreatePullRequestAndGetPreviewEnvironment(statusCode int) error {
 	prNumber := pr.Number
 	Expect(prNumber).ShouldNot(BeNil())
 
-	jobName := owner + "/" + appName + "/PR-" + strconv.Itoa(*prNumber)
+	jobName := owner + "/" + applicationName + "/PR-" + strconv.Itoa(*prNumber)
 
 	t.ThereShouldBeAJobThatCompletesSuccessfully(jobName, 10*time.Minute)
 
@@ -210,13 +210,13 @@ func (t *Test) CreatePullRequestAndGetPreviewEnvironment(statusCode int) error {
 	for _, env := range envList.Items {
 		spec := &env.Spec
 		if spec.Kind == v1.EnvironmentKindTypePreview {
-			if spec.PreviewGitSpec.ApplicationName == appName {
+			if spec.PreviewGitSpec.ApplicationName == applicationName {
 				copy := env
 				previewEnv = &copy
 			}
 		}
 	}
-	Expect(previewEnv).ShouldNot(BeNil(), "Could not find Preview Environment in namespace %s for app name %s", ns, appName)
+	Expect(previewEnv).ShouldNot(BeNil(), "Could not find Preview Environment in namespace %s for application name %s", ns, applicationName)
 	if previewEnv != nil {
 		appUrl := previewEnv.Spec.PreviewGitSpec.ApplicationURL
 		Expect(appUrl).ShouldNot(Equal(""), "No Preview Application URL found")
@@ -225,7 +225,7 @@ func (t *Test) CreatePullRequestAndGetPreviewEnvironment(statusCode int) error {
 
 		return t.ExpectUrlReturns(appUrl, statusCode, time.Minute*5)
 	} else {
-		utils.LogInfof("No Preview Environment found in namespace %s for application: %s\n", ns, appName)
+		utils.LogInfof("No Preview Environment found in namespace %s for application: %s\n", ns, applicationName)
 	}
 	return nil
 }
@@ -246,13 +246,13 @@ func RetryExponentialBackoff(maxDuration time.Duration, f func() error) error {
 	return err
 }
 
-// GetAppName gets the app name for the current test case
-func (t *Test) GetAppName() string {
-	appName := t.AppName
-	if appName == "" {
-		_, appName = filepath.Split(t.WorkDir)
+// GetApplicationName gets the application name for the current test case
+func (t *Test) GetApplicationName() string {
+	applicationName := t.ApplicationName
+	if applicationName == "" {
+		_, applicationName = filepath.Split(t.WorkDir)
 	}
-	return appName
+	return applicationName
 }
 
 // ExpectCommandExecution performs the given command in the current work directory and asserts that it completes successfully
@@ -268,8 +268,8 @@ func (t *Test) ExpectCommandExecution(dir string, commandTimeout time.Duration, 
 	Ω(err).ShouldNot(HaveOccurred())
 }
 
-// DeleteApps should we delete apps after the quickstart has run
-func (t *Test) DeleteApps() bool {
+// DeleteApplications should we delete apps after the quickstart has run
+func (t *Test) DeleteApplications() bool {
 	text := os.Getenv("JX_DISABLE_DELETE_APP")
 	return strings.ToLower(text) != "true"
 }
@@ -322,15 +322,15 @@ func CreateQuickstartTests(quickstartName string) bool {
 		var T Test
 
 		BeforeEach(func() {
-			appName := TempDirPrefix + quickstartName + "-" + strconv.FormatInt(GinkgoRandomSeed(), 10)
+			applicationName := TempDirPrefix + quickstartName + "-" + strconv.FormatInt(GinkgoRandomSeed(), 10)
 			T = Test{
-				AppName: appName,
-				WorkDir: WorkDir,
-				Factory: cmd.NewFactory(),
+				ApplicationName: applicationName,
+				WorkDir:         WorkDir,
+				Factory:         cmd.NewFactory(),
 			}
 			T.GitProviderURL()
 
-			utils.LogInfof("Creating app %s in dir %s\n", util.ColorInfo(appName), util.ColorInfo(WorkDir))
+			utils.LogInfof("Creating application %s in dir %s\n", util.ColorInfo(applicationName), util.ColorInfo(WorkDir))
 		})
 
 		commandTimeout := 1 * time.Hour
@@ -338,7 +338,7 @@ func CreateQuickstartTests(quickstartName string) bool {
 			Context("when operating on the quickstart", func() {
 				It("creates a "+quickstartName+" quickstart and promotes it to staging\n", func() {
 					c := "jx"
-					args := []string{"create", "quickstart", "-b", "--org", T.GetGitOrganisation(), "-p", T.AppName, "-f", quickstartName}
+					args := []string{"create", "quickstart", "-b", "--org", T.GetGitOrganisation(), "-p", T.ApplicationName, "-f", quickstartName}
 
 					gitProviderUrl, err := T.GitProviderURL()
 					Expect(err).NotTo(HaveOccurred())
@@ -365,10 +365,10 @@ func CreateQuickstartTests(quickstartName string) bool {
 						T.CreatePullRequestAndGetPreviewEnvironment(200)
 					}
 
-					if T.DeleteApps() {
-						By("deletes the app")
-						fullAppName := T.GetGitOrganisation() + "/" + T.AppName
-						args = []string{"delete", "app", "-b", fullAppName}
+					if T.DeleteApplications() {
+						By("deletes the application")
+						fullApplicationName := T.GetGitOrganisation() + "/" + T.ApplicationName
+						args = []string{"delete", "application", "-b", fullApplicationName}
 						command = exec.Command(c, args...)
 						command.Dir = T.WorkDir
 						session, err = gexec.Start(command, GinkgoWriter, GinkgoWriter)
@@ -379,7 +379,7 @@ func CreateQuickstartTests(quickstartName string) bool {
 
 					if T.DeleteRepos() {
 						By("deletes the repo")
-						args = []string{"delete", "repo", "-b", "--github", "-o", T.GetGitOrganisation(), "-n", T.AppName}
+						args = []string{"delete", "repo", "-b", "--github", "-o", T.GetGitOrganisation(), "-n", T.ApplicationName}
 						command = exec.Command(c, args...)
 						command.Dir = T.WorkDir
 						session, err = gexec.Start(command, GinkgoWriter, GinkgoWriter)
@@ -401,7 +401,7 @@ func CreateQuickstartTests(quickstartName string) bool {
 			Context("when -f param (filter) does not match any quickstart", func() {
 				It("exits with signal 1\n", func() {
 					c := "jx"
-					args := []string{"create", "quickstart", "-b", "--org", T.GetGitOrganisation(), "-p", T.AppName, "-f", "the_derek_zoolander_app_for_being_really_really_good_looking"}
+					args := []string{"create", "quickstart", "-b", "--org", T.GetGitOrganisation(), "-p", T.ApplicationName, "-f", "the_derek_zoolander_app_for_being_really_really_good_looking"}
 					T.ExpectCommandExecution(T.WorkDir, commandTimeout, 1, c, args...)
 				})
 			})


### PR DESCRIPTION
update the code to reflect this.
Whilst most of this is cosmetic, the commands to run `jx delete app` are now out of date and failing (because the command used to be `jx delete app` (meaning delete an application) but has now changed to be `jx delete application` so as not to conflict with the entirely different `jx delete app` (meaning delete a platform addon) command.

The main cause of this was at the end of the tests, the cleanup code did `jx delete app <appname> -b` and resulted in `Error: unknown shorthand flag: 'b' in -b` because `jx delete app` has a new meaning.