### PR TITLE
feat: Add app tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -89,6 +89,12 @@ test-parallel: info
 test-import: info
 	$(GINKGO) --slowSpecThreshold=50000 --focus=import
 
+test-app-jacoco: info
+	$(GINKGO) --slowSpecThreshold=50000 --focus="test app" -- -include-apps=jx-app-jacoco:0.0.100
+
+test-app: info
+	$(GINKGO) --slowSpecThreshold=50000 --focus="test app" -- -include-apps=$(JX_BDD_INCLUDE_APPS)
+
 test-create-spring: info
 	$(GINKGO) --slowSpecThreshold=50000 --focus="create spring"
 

--- a/Makefile
+++ b/Makefile
@@ -89,7 +89,7 @@ test-parallel: info
 test-import: info
 	$(GINKGO) --slowSpecThreshold=50000 --focus=import
 
-test-app-jacoco: info
+test-app-lifecycle: info
 	$(GINKGO) --slowSpecThreshold=50000 --focus="test app" -- -include-apps=jx-app-jacoco:0.0.100
 
 test-app: info

--- a/Readme.md
+++ b/Readme.md
@@ -41,6 +41,18 @@ To enable verbose logging do this before running `make`
 
     export GINKGO_ARGS=-v
 
+## Running the Apps BDD tests
+  
+To run a test suite against the jacoco app you can run: 
+   
+    make test-app-jacoco 
+    
+This will test `jx add app` and `jx delete app` against a known stable version of jx-app-jacoco
+   
+To run the same tests as above against multiple apps and versions you can use the following syntax: 
+
+    JX_BDD_INCLUDE_APPS=jx-app-jacoco:0.0.100,my-app:0.0.1 make test-app        
+
 ## Environment variables
 
 * `GINKGO_ARGS` to pass in any [ginkgo command line arguments](http://onsi.github.io/ginkgo/#the-ginkgo-cli, like `-v` for verbose logging

--- a/Readme.md
+++ b/Readme.md
@@ -45,7 +45,7 @@ To enable verbose logging do this before running `make`
   
 To run a test suite against the jacoco app you can run: 
    
-    make test-app-jacoco 
+    make test-app-lifecycle 
     
 This will test `jx add app` and `jx delete app` against a known stable version of jx-app-jacoco
    

--- a/jx_test_app.go
+++ b/jx_test_app.go
@@ -1,0 +1,3 @@
+package bdd_jx
+
+var _ = AppTests()

--- a/main.go
+++ b/main.go
@@ -1,6 +1,7 @@
 package bdd_jx
 
 import (
+	"flag"
 	"fmt"
 	"github.com/jenkins-x/bdd-jx/utils"
 	"io/ioutil"
@@ -29,7 +30,9 @@ var (
 	// TempDirPrefix The prefix to append to apps created in testing
 	TempDirPrefix = "bdd-"
 	// WorkDir The current working directory
-	WorkDir string
+	WorkDir              string
+	IncludeApps          = flag.String("include-apps", "", "The Jenkins X App names to BDD test")
+	DefaultRepositoryURL = "http://chartmuseum.jenkins-x.io"
 )
 
 // Test is the standard testing object
@@ -262,6 +265,7 @@ func (t *Test) ExpectCommandExecution(dir string, commandTimeout time.Duration, 
 		command.Dir = dir
 		session, err := gexec.Start(command, GinkgoWriter, GinkgoWriter)
 		session.Wait(commandTimeout)
+		Eventually(session).Should(gexec.Exit(exitCode))
 		return err
 	}
 	err := RetryExponentialBackoff((1 * time.Minute), f)
@@ -314,6 +318,98 @@ func (t *Test) ExpectUrlReturns(url string, expectedStatusCode int, maxDuration 
 		return fmt.Errorf("Invalid HTTP status code for %s expected %d but got %d", url, expectedStatusCode, actualStatusCode)
 	}
 	return RetryExponentialBackoff(maxDuration, f)
+}
+
+// AddAppTests Creates a jx add app test
+func AppTests() []bool {
+	flag.Parse()
+	includedApps := *IncludeApps
+	if includedApps != "" {
+		includedAppList := strings.Split(strings.TrimSpace(includedApps), ",")
+		tests := make([]bool, len(includedAppList))
+		for _, testAppName := range includedAppList {
+			nameAndVersion := strings.Split(testAppName, ":")
+			if len(nameAndVersion) == 2 {
+				tests = append(tests, AppTest(nameAndVersion[0], nameAndVersion[1]))
+			} else {
+				tests = append(tests, AppTest(testAppName, ""))
+			}
+
+		}
+		return tests
+	} else {
+		return nil
+	}
+}
+
+func AppTest(testAppName string, version string) bool {
+	return Describe("test app "+testAppName+"\n", func() {
+		var T Test
+
+		BeforeEach(func() {
+			T = Test{
+				AppName: TempDirPrefix + testAppName + "-" + strconv.FormatInt(GinkgoRandomSeed(), 10),
+				WorkDir: WorkDir,
+				Factory: cmd.NewFactory(),
+			}
+			T.GitProviderURL()
+		})
+
+		_ = T.AddAppTests(testAppName, version)
+		_ = T.DeleteAppTests(testAppName)
+
+	})
+}
+
+// AddAppTests add app tests
+func (t *Test) AddAppTests(testAppName string, version string) bool {
+	return Describe("Given valid parameters", func() {
+		Context("when running jx add app "+testAppName, func() {
+			commandTimeout := 1 * time.Hour
+			helmAppName := testAppName + "-" + testAppName
+			It("Ensure the app is added\n", func() {
+				By("The App resource does not exist before creation\n")
+				c := "kubectl"
+				args := []string{"get", "app", helmAppName}
+				t.ExpectCommandExecution(t.WorkDir, commandTimeout, 1, c, args...)
+				By("Add app exits with signal 0\n")
+				c = "jx"
+				args = []string{"add", "app", testAppName, "--repository", DefaultRepositoryURL}
+				if version != "" {
+					args = append(args, "--version", version)
+				}
+				t.ExpectCommandExecution(t.WorkDir, commandTimeout, 0, c, args...)
+				By("The App resource exists after creation\n")
+				c = "kubectl"
+				args = []string{"get", "app", helmAppName}
+				t.ExpectCommandExecution(t.WorkDir, commandTimeout, 0, c, args...)
+			})
+		})
+	})
+}
+
+// DeleteAppTests delete app tests
+func (t *Test) DeleteAppTests(testAppName string) bool {
+	return Describe("Given valid parameters", func() {
+		Context("when running jx delete app "+testAppName, func() {
+			commandTimeout := 1 * time.Hour
+			helmAppName := testAppName + "-" + testAppName
+			It("Ensure it is deleted\n", func() {
+				By("The App resource exists before deletion\n")
+				c := "kubectl"
+				args := []string{"get", "app", helmAppName}
+				t.ExpectCommandExecution(t.WorkDir, commandTimeout, 0, c, args...)
+				By("Delete app exits with signal 0\n")
+				c = "jx"
+				args = []string{"delete", "app", testAppName}
+				t.ExpectCommandExecution(t.WorkDir, commandTimeout, 0, c, args...)
+				By("The App resource was removed\n")
+				c = "kubectl"
+				args = []string{"get", "app", helmAppName}
+				t.ExpectCommandExecution(t.WorkDir, commandTimeout, 1, c, args...)
+			})
+		})
+	})
 }
 
 // CreateQuickstartTests Creates quickstart tests


### PR DESCRIPTION
This PR adds support for testing:

- `jx add app`
- `jx delete app`

To run a once off test using a known version of the jacoco app you can run: `make test-app-lifecycle`
To run a test against multiple apps and versions you use the following syntax: `JX_BDD_INCLUDE_APPS=jx-app-jacoco:0.0.100,my-app:0.0.1 make test-app`