### PR TITLE
fix: Skip manual promotion if env var is set.

### DIFF
--- a/test/spring/jx_create_spring.go
+++ b/test/spring/jx_create_spring.go
@@ -2,6 +2,7 @@ package spring
 
 import (
 	"fmt"
+	"os"
 	"strconv"
 	"strings"
 
@@ -10,6 +11,10 @@ import (
 	"github.com/jenkins-x/bdd-jx/test/utils"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+)
+
+var (
+	SkipManualPromotion = os.Getenv("JX_BDD_SKIP_MANUAL_PROMOTION")
 )
 
 var _ = Describe("create spring\n", func() {
@@ -53,12 +58,14 @@ var _ = Describe("create spring\n", func() {
 					})
 				}
 
-				args = []string{"promote", "--env", "production", "--version", "0.0.1", T.ApplicationName}
-				By("manually promoting app to production environment", func() {
-					T.ExpectJxExecution(T.WorkDir, helpers.TimeoutSessionWait, 0, args...)
-					T.TheApplicationIsRunningInProduction(404)
-				})
-
+				if SkipManualPromotion == "" {
+					args = []string{"promote", "--env", "production", "--version", "0.0.1", T.ApplicationName}
+					By("manually promoting app to production environment", func() {
+						T.ExpectJxExecution(T.WorkDir, helpers.TimeoutSessionWait, 0, args...)
+						T.TheApplicationIsRunningInProduction(404)
+					})
+				}
+				
 				if T.DeleteApplications() {
 					args = []string{"delete", "application", "-b", T.ApplicationName}
 					argsStr := strings.Join(args, " ")


### PR DESCRIPTION
This fixes the `bdd` context on `jx` that was broken by https://github.com/jenkins-x/bdd-jx/pull/45, by letting us disable manual promotion for just that run.

/assign @fiunchinho 
/assign @jstrachan 