### PR TITLE
fix: node-http-watch-pipeline-activity is broken, use node-http instead

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -136,7 +136,7 @@ test-parallel: info
 	$(GINKGO) --slowSpecThreshold=$(SLOW_SPEC_THRESHOLD) -p --nodes 8
 
 test-import: info
-	JX_BDD_IMPORTS=node-http-watch-pipeline-activity,spring-boot-rest-prometheus,spring-boot-http-gradle,golang-http $(GINKGO) test/_import --slowSpecThreshold=$(SLOW_SPEC_THRESHOLD)
+	JX_BDD_IMPORTS=node-http,spring-boot-rest-prometheus,spring-boot-http-gradle,golang-http $(GINKGO) test/_import --slowSpecThreshold=$(SLOW_SPEC_THRESHOLD)
 
 test-app-lifecycle: info
 	JX_BDD_INCLUDE_APPS="$(JX_BDD_INCLUDE_APPS)" $(GINKGO) test/apps --slowSpecThreshold=$(SLOW_SPEC_THRESHOLD)


### PR DESCRIPTION
So `node-http-watch-pipeline-activity` fails with
```
> REPLACE_ME@1.0.0 start /usr/src/app
> node server.js

/usr/src/app/server.js:48
        ct = moment(object.object.metadata.creationTimestamp);
                                  ^

TypeError: Cannot read property 'metadata' of undefined
    at module.exports.JSONStream.jsonStream.on.object (/usr/src/app/server.js:48:29)
    at module.exports.JSONStream.emit (events.js:180:13)
    at addChunk (_stream_readable.js:274:12)
    at readableAddChunk (_stream_readable.js:261:11)
    at module.exports.JSONStream.Readable.push (_stream_readable.js:218:10)
    at module.exports.JSONStream.Transform.push (_stream_transform.js:146:32)
    at module.exports.JSONStream.JSONStream._transform (/usr/src/app/node_modules/json-stream/lib/json-stream.js:32:14)
    at module.exports.JSONStream.Transform._read (_stream_transform.js:185:10)
    at module.exports.JSONStream.Transform._write (_stream_transform.js:173:12)
    at doWrite (_stream_writable.js:410:12)
npm ERR! code ELIFECYCLE
npm ERR! errno 1
npm ERR! REPLACE_ME@1.0.0 start: `node server.js`
npm ERR! Exit status 1
npm ERR!
npm ERR! Failed at the REPLACE_ME@1.0.0 start script.
npm ERR! This is probably not a problem with npm. There is likely additional logging output above.

npm ERR! A complete log of this run can be found in:
npm ERR!     /root/.npm/_logs/2019-07-22T19_44_01_548Z-debug.log
```

We probably shouldn't be using that in the import test.

Signed-off-by: Andrew Bayer <andrew.bayer@gmail.com>