### PR TITLE
fix: Turn back on checking the activity's status

### DIFF
--- a/test/helpers/test.go
+++ b/test/helpers/test.go
@@ -298,12 +298,14 @@ func (t *TestOptions) ThereShouldBeAJobThatCompletesSuccessfully(jobName string,
 		}
 	})
 
+	var activity *parsers.Activity
+	var ok bool
 	activityKey := fmt.Sprintf("%s #%d", jobName, 1)
 	By(fmt.Sprintf("finding the activity for %s in %v", activityKey, activities), func() {
 		// TODO disabling this for now as we get a failure on ng
 		if activities != nil {
 			Expect(activities).Should(HaveLen(1), fmt.Sprintf("should be one activity but found %d having run jx get activities --filter %s --build 1; activities %v", len(activities), jobName, activities))
-			activity, ok := activities[fmt.Sprintf("%s #%d", jobName, 1)]
+			activity, ok = activities[fmt.Sprintf("%s #%d", jobName, 1)]
 			if !ok {
 				// TODO lets see if the build is number 2 instead which it is for tekton currently
 				activity, ok = activities[fmt.Sprintf("%s #%d", jobName, 2)]
@@ -315,12 +317,7 @@ func (t *TestOptions) ThereShouldBeAJobThatCompletesSuccessfully(jobName string,
 	})
 
 	By(fmt.Sprintf("checking that the activity %s has succeeded", activityKey), func() {
-		// TODO lets temporarily disable this assertion as we have an issue on our production cluster with build statuses not being set correctly
-		// TODO lets put this back ASAP once we're on tekton!
-		/*
-			Expect(activity.Spec.Status.IsTerminated()).To(BeTrue())
-			Expect(activity.Spec.Status.String()).Should(Equal("Succeeded"))
-		*/
+		Expect(activity.Status).Should(Equal("Succeeded"))
 	})
 }
 

--- a/test/utils/parsers/get_activities_parser.go
+++ b/test/utils/parsers/get_activities_parser.go
@@ -95,6 +95,13 @@ func ParseJxGetActivities(s string) (map[string]*Activity, error) {
 					Status:     fields[4],
 				}
 				currentStage.Steps = append(currentStage.Steps, step)
+			} else if fields[2] == "Pending" {
+				// This means that the step hasn't started yet.
+				step := &Step{
+					Name: fields[1],
+					Status: fields[2],
+				}
+				currentStage.Steps = append(currentStage.Steps, step)
 			} else {
 				return  nil, errors.Errorf("Unable to parse %s as step, entire output was %s", line, s)
 			}


### PR DESCRIPTION
In https://github.com/jenkins-x/jx/pull/5001, it wasn't clear what was going wrong - turns out it was that `jx get build logs` terminated too soon, but the test went past where the actual failure was (in the parsing of `jx get activity`) and doesn't actually check the status of the activity anyway. Since there was a big ol' `TODO` to turn that back on once we moved to Tekton...well, we've long since moved to Tekton, so let's do this thing.

/assign @pmuir 