### PR TITLE
fix: a fix to ginkgo-focus syntax

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -54,7 +54,7 @@ test-upgrade-platform:
 	$(GO) test $(TESTFLAGS) ./test/suite/platform
 
 test-supported-quickstarts:
-	JX_BDD_QUICKSTARTS= $(GO) test $(TESTFLAGS) ./test/suite/quickstart -ginkgo.focus=(node-http|spring-boot-http-gradle|golang-http)
+	JX_BDD_QUICKSTARTS= $(GO) test $(TESTFLAGS) ./test/suite/quickstart -ginkgo.focus='(node-http|spring-boot-http-gradle|golang-http)'
 
 test-devpod:
 	$(GO) test $(TESTFLAGS) ./test/suite/devpods


### PR DESCRIPTION
This is needed because some BDD tests are failing with:

```
JX_BDD_QUICKSTARTS= GO111MODULE=on go test -v -timeout 2h ./test/suite/quickstart -ginkgo.focus=(node-http|spring-boot-http-gradle|golang-http)
/bin/sh: -c: line 0: syntax error near unexpected token `('
/bin/sh: -c: line 0: `JX_BDD_QUICKSTARTS= GO111MODULE=on go test -v -timeout 2h ./test/suite/quickstart -ginkgo.focus=(node-http|spring-boot-http-gradle|golang-http)'
```