### PR TITLE
fix: set the correct WorkDir and enable default reporter again for better feedback

### DIFF
--- a/test/helpers/suite.go
+++ b/test/helpers/suite.go
@@ -50,7 +50,7 @@ func RunWithReporters(t *testing.T, suiteId string) {
 	config.DefaultReporterConfig.Verbose = testing.Verbose()
 	reporters = append(reporters, gr.NewJUnitReporter(filepath.Join(reportsDir, fmt.Sprintf("%s.junit.xml", suiteId))))
 	RegisterFailHandler(Fail)
-	RunSpecsWithCustomReporters(t, fmt.Sprintf("Jenkins X E2E tests: %s", suiteId), reporters)
+	RunSpecsWithDefaultAndCustomReporters(t, fmt.Sprintf("Jenkins X E2E tests: %s", suiteId), reporters)
 }
 
 var BeforeSuiteCallback = func() {
@@ -61,6 +61,7 @@ var BeforeSuiteCallback = func() {
 	err = os.MkdirAll(WorkDir, 0760)
 	Expect(err).NotTo(HaveOccurred())
 	Expect(WorkDir).To(BeADirectory())
+	AssignWorkDirValue(WorkDir)
 }
 
 var SynchronizedAfterSuiteCallback = func() {

--- a/test/helpers/test.go
+++ b/test/helpers/test.go
@@ -58,6 +58,10 @@ type TestOptions struct {
 	Organisation    string
 }
 
+func AssignWorkDirValue(generatedWorkDir string) {
+	WorkDir = generatedWorkDir
+}
+
 // GetGitOrganisation Gets the current git organisation/user
 func (t *TestOptions) GetGitOrganisation() string {
 	org := os.Getenv("GIT_ORGANISATION")


### PR DESCRIPTION
We disabled the default reporter so we are not getting things like: 
```
Ran 4 of 4 Specs in 1462.171 seconds
SUCCESS! -- 4 Passed | 0 Failed | 0 Pending | 0 Skipped
--- PASS: TestSuite (1462.17s)
PASS
```
And added a fix to set the WorkDir variable.