### PR TITLE
fix: test-quickstart-golang-http should just run one quickstart

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -61,7 +61,7 @@ test-devpod:
 
 #targets for individual quickstarts
 test-quickstart-golang-http:
-	$(GO) test $(TESTFLAGS) ./test/suite/quickstart -ginkgo.focus=golang-http
+	$(GO) test $(TESTFLAGS) ./test/suite/quickstart -ginkgo.focus='golang-http$'
 
 test-import-golang-http-from-jenkins-x-yml:
 	$(GO) test $(TESTFLAGS) ./test/suite/_import -ginkgo.focus=golang-http-from-jenkins-x-yml


### PR DESCRIPTION
`-ginkgo.focus=golang-http` results in both `golang-http` and
`golang-http-from-jenkins-x-yml` being run, since `-ginkgo.focus` is
doing a regex match. I think this should keep it from doing that.

Signed-off-by: Andrew Bayer <andrew.bayer@gmail.com>