### PR TITLE
Revert "fix: test-quickstart-golang-http should just run one quickstart"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -61,7 +61,7 @@ test-devpod:
 
 #targets for individual quickstarts
 test-quickstart-golang-http:
-	$(GO) test $(TESTFLAGS) ./test/suite/quickstart -ginkgo.focus='golang-http$'
+	$(GO) test $(TESTFLAGS) ./test/suite/quickstart -ginkgo.focus=golang-http
 
 test-import-golang-http-from-jenkins-x-yml:
 	$(GO) test $(TESTFLAGS) ./test/suite/_import -ginkgo.focus=golang-http-from-jenkins-x-yml


### PR DESCRIPTION
Argh, this didn't work and in fact broke everything.

Reverts jenkins-x/bdd-jx#75