### PR TITLE
chore: Add target for running a single import

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -65,6 +65,10 @@ test-quickstart-golang-http:
 
 test-import-golang-http-from-jenkins-x-yml:
 	$(GO) test $(TESTFLAGS) ./test/suite/_import -ginkgo.focus=golang-http-from-jenkins-x-yml
+
+test-single-import:
+	$(GO) test $(TESTFLAGS) ./test/suite/_import -ginkgo.focus=${BDD_TEST_SINGLE_IMPORT}
+
 bdd-init:
 	echo "About to run the BDD tests on the current cluster"
 	git config --global credential.helper store


### PR DESCRIPTION
It'll run with the focus on whatever the value of
`${BDD_TEST_SINGLE_IMPORT}` is set to. This will let us change the
`jenkins-x-versions` tests to run individual imports in different
contexts, which will speed up the `tekton` context (currently the long
poll for the `jenkins-x-versions` PR tests to finish) by having it
only run one import while, say, `boot-local`, `boot-vault`, and `ng`
each run one of the three imports.

Signed-off-by: Andrew Bayer <andrew.bayer@gmail.com>