### PR TITLE
feat(prow): Add BDD tests for ChatOps commands

### DIFF
--- a/test/suite/quickstart/helpers.go
+++ b/test/suite/quickstart/helpers.go
@@ -131,6 +131,7 @@ func createQuickstartTests(quickstartName string) bool {
 
 							By("adding a WIP label", func() {
 								err = T.AddWIPLabelToPRByUpdatingTitle(gitProvider, owner, applicationName)
+								Expect(err).NotTo(HaveOccurred())
 							})
 						}
 					} else {


### PR DESCRIPTION
This PR is part of the broader outlined in https://github.com/jenkins-x/lighthouse/issues/64 and specifically addresses https://github.com/jenkins-x/lighthouse/issues/185 and https://github.com/jenkins-x/lighthouse/issues/186. 

These are a first attempt at testing the /approve and /lgtm ChatOps commands.

Fixes https://github.com/jenkins-x/lighthouse/issues/185
Fixes https://github.com/jenkins-x/lighthouse/issues/186