### PR TITLE
fix: Run BDD tests against a fresh cluster for bdd-jx PRs

### DIFF
--- a/jenkins-x-release.yml
+++ b/jenkins-x-release.yml
@@ -1,0 +1,18 @@
+buildPack: none
+noReleasePrepare: true
+pipelineConfig:
+  pipelines:
+    release:
+      pipeline:
+        agent:
+          image: gcr.io/jenkinsxio/builder-go-maven
+        stages:
+          - name: bdd-stage
+            steps:
+              - name: build
+                command: make build
+                env:
+                - name: GIT_AUTHOR_NAME
+                  value: jenkins-x-bot
+                - name: GIT_AUTHOR_EMAIL
+                  value: jenkins-x@googlegroups.com

--- a/jenkins-x.yml
+++ b/jenkins-x.yml
@@ -21,13 +21,46 @@ pipelineConfig:
       pipeline:
         agent:
           image: gcr.io/jenkinsxio/builder-go-maven
+        environment:
+          - name: GIT_AUTHOR_NAME
+            value: jenkins-x-bot
+          - name: GIT_AUTHOR_EMAIL
+            value: jenkins-x@googlegroups.com
+          - name: GOPROXY
+            value: http://jenkins-x-athens-proxy:80
+          - name: GKE_SA
+            value: /secrets/bdd/sa.json
+          - name: GH_ACCESS_TOKEN
+            valueFrom:
+              secretKeyRef:
+                name: jenkins-x-bot-test-github
+                key: password
+          - name: JENKINS_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: test-jenkins-user
+                key: password
         stages:
           - name: bdd-stage
+            options:
+              volumes:
+                - name: sa
+                  secret:
+                    secretName: bdd-secret
+                    items:
+                      - key: bdd-credentials.json
+                        path: bdd/sa.json
+              containerOptions:
+                resources:
+                  limits:
+                    cpu: 4
+                    memory: 6144Mi
+                  requests:
+                    cpu: 1
+                    memory: 2048Mi
+                volumeMounts:
+                  - mountPath: /secrets
+                    name: sa
             steps:
-              - name: build
-                command: make build
-                env:
-                  - name: GIT_AUTHOR_NAME
-                    value: jenkins-x-bot
-                  - name: GIT_AUTHOR_EMAIL
-                    value: jenkins-x@googlegroups.com
+              - name: run-bdd
+                command: jx/bdd/ci.sh

--- a/jx/bdd/README.md
+++ b/jx/bdd/README.md
@@ -1,0 +1,1 @@
+## BDD test using JX Boot with Vault and long term storage

--- a/jx/bdd/ci.sh
+++ b/jx/bdd/ci.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+set -e
+set -x
+
+export GH_USERNAME="jenkins-x-bot-test"
+export GH_EMAIL="jenkins-x@googlegroups.com"
+export GH_OWNER="jenkins-x-bot-test"
+
+# fix broken `BUILD_NUMBER` env var
+export BUILD_NUMBER="$BUILD_ID"
+
+JX_HOME="/tmp/jxhome"
+KUBECONFIG="/tmp/jxhome/config"
+
+mkdir -p $JX_HOME
+
+jx --version
+jx step git credentials
+
+gcloud auth activate-service-account --key-file $GKE_SA
+
+# lets setup git 
+git config --global --add user.name JenkinsXBot
+git config --global --add user.email jenkins-x@googlegroups.com
+
+echo "running the BDD tests with JX_HOME = $JX_HOME"
+
+# setup jx boot parameters
+export JX_VALUE_ADMINUSER_PASSWORD="$JENKINS_PASSWORD"
+export JX_VALUE_PIPELINEUSER_USERNAME="$GH_USERNAME"
+export JX_VALUE_PIPELINEUSER_EMAIL="$GH_EMAIL"
+export JX_VALUE_PIPELINEUSER_TOKEN="$GH_ACCESS_TOKEN"
+export JX_VALUE_PROW_HMACTOKEN="$GH_ACCESS_TOKEN"
+
+# TODO temporary hack until the batch mode in jx is fixed...
+export JX_BATCH_MODE="true"
+
+# TODO: Make "jx step bdd" able to just use the current directory/checkout. It can use an existing clone of bdd-jx, but
+# it expects it to be at /tmp/jenkins-x/bdd-jx, which doesn't fit here, so for the moment, we'll just copy the entire
+# repo to there.
+mkdir -p /tmp/jenkins-x/bdd-jx
+cp -r $PWD/* /tmp/jenkins-x/bdd-jx/
+
+git clone https://github.com/jenkins-x/jenkins-x-boot-config.git boot-source
+cp jx/bdd/jx-requirements.yml boot-source
+cp jx/bdd/parameters.yaml boot-source/env
+cd boot-source
+
+# TODO hack until we fix boot to do this too!
+helm init --client-only
+helm repo add jenkins-x https://storage.googleapis.com/chartmuseum.jenkins-x.io
+
+# Just run the golang-http-from-jenkins-x-yml import test here
+export BDD_TEST_SINGLE_IMPORT="golang-http-from-jenkins-x-yml"
+
+# TODO: Are there other tests we should be running on every PR? Starting with create spring, a single import, a single
+# quickstart, and the app lifecycle.
+jx step bdd \
+    --skip-test-git-repo-clone \
+    --versions-repo https://github.com/jenkins-x/jenkins-x-versions.git \
+    --config ../jx/bdd/cluster.yaml \
+    --gopath /tmp \
+    --git-provider=github \
+    --git-username $GH_USERNAME \
+    --git-owner $GH_OWNER \
+    --git-api-token $GH_ACCESS_TOKEN \
+    --default-admin-password $JENKINS_PASSWORD \
+    --no-delete-app \
+    --no-delete-repo \
+    --tests install \
+    --tests test-create-spring \
+    --tests test-single-import \
+    --tests test-quickstart-golang-http \
+    --tests test-app-lifecycle
+

--- a/jx/bdd/cluster.yaml
+++ b/jx/bdd/cluster.yaml
@@ -1,0 +1,18 @@
+clusters:
+  - name: bdd-jx-bdd
+    args:
+      - create
+      - cluster
+      - gke
+      - --project-id=jenkins-x-bdd3
+      - -m=n1-standard-2
+      - --min-num-nodes=3
+      - --max-num-nodes=5
+      - -z=europe-west1-c
+      - --skip-login
+      - --skip-installation
+    commands:
+      - command: jx
+        args:
+          - boot
+          - -b

--- a/jx/bdd/jx-requirements.yml
+++ b/jx/bdd/jx-requirements.yml
@@ -1,0 +1,37 @@
+cluster:
+  clusterName: bdd-jx-bdd
+  environmentGitOwner: jenkins-x-bot-test
+  project: jenkins-x-bdd3
+  provider: gke
+  zone: europe-west1-c
+environments:
+  - key: dev
+    owner: ""
+    repository: ""
+  - key: staging
+    owner: ""
+    repository: ""
+  - key: production
+    owner: ""
+    repository: ""
+ingress:
+  domain: ""
+  externalDNS: false
+  tls:
+    email: ""
+    enabled: false
+    production: false
+kaniko: true
+repository: nexus
+secretStorage: vault
+storage:
+  logs:
+    enabled: true
+    url: "gs://jx-bdd-log-store3"
+  reports:
+    enabled: true
+    url: "gs://jx-bdd-log-store3"
+vault:
+  disableURLDiscovery: true
+webhook: prow
+

--- a/jx/bdd/parameters.yaml
+++ b/jx/bdd/parameters.yaml
@@ -1,0 +1,10 @@
+adminUser:
+  username: admin
+enableDocker: false
+gitProvider: github
+gpg: {}
+pipelineUser:
+  github:
+    host: github.com
+    username: jenkins-x-bot-test
+    email: jenkins-x@googlegroups.com


### PR DESCRIPTION
Also adds `jenkins-x-release.yml`, which we'll need once https://github.com/jenkins-x/environment-tekton-weasel-dev/pull/273 is merged.

fixes #6116
