### PR TITLE
chore: make the upgrade ref and binary overwrite 

### DIFF
--- a/jenkins-x.yml
+++ b/jenkins-x.yml
@@ -33,7 +33,7 @@ pipelineConfig:
           - name: GH_ACCESS_TOKEN
             valueFrom:
               secretKeyRef:
-                name: jenkins-x-bot-test-github
+                name: jenkins-x-versions-bot-test-github
                 key: password
           - name: JENKINS_PASSWORD
             valueFrom:

--- a/jx/bdd/ci.sh
+++ b/jx/bdd/ci.sh
@@ -2,9 +2,9 @@
 set -e
 set -x
 
-export GH_USERNAME="jenkins-x-bot-test"
+export GH_USERNAME="jenkins-x-versions-bot-test"
 export GH_EMAIL="jenkins-x@googlegroups.com"
-export GH_OWNER="jenkins-x-bot-test"
+export GH_OWNER="jenkins-x-versions-bot-test"
 
 # fix broken `BUILD_NUMBER` env var
 export BUILD_NUMBER="$BUILD_ID"
@@ -12,10 +12,15 @@ export BUILD_NUMBER="$BUILD_ID"
 JX_HOME="/tmp/jxhome"
 KUBECONFIG="/tmp/jxhome/config"
 
-mkdir -p $JX_HOME
+# lets avoid the git/credentials causing confusion during the test
+export XDG_CONFIG_HOME=$JX_HOME
+
+mkdir -p $JX_HOME/git
 
 jx --version
-jx step git credentials
+
+# replace the credentials file with a single user entry
+echo "https://$GH_USERNAME:$GH_ACCESS_TOKEN@github.com" > $JX_HOME/git/credentials
 
 gcloud auth activate-service-account --key-file $GKE_SA
 


### PR DESCRIPTION
This PR makes the binary override  optional and the upgrade ref configurable when running the upgrade boot bdd test