### PR TITLE
feat: disable chatops commands testing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,7 @@ ifdef DEBUG
 BUILDFLAGS += -gcflags "all=-N -l" $(BUILDFLAGS)
 endif
 
+export JX_DISABLE_TEST_CHATOPS_COMMANDS=true
 
 all: build
 


### PR DESCRIPTION
Disabling chatops commands testing because it doesn't really provide a lot of value and it's causing issues for some BDD tests.