### PR TITLE
chore: displaying the git-credentials to the console

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -85,6 +85,7 @@ bdd-init:
 	jx step git credentials
 	ls -al ~
 	cat ~/.gitconfig
+	cat ~/.git-credentials
 
 bdd: bdd-init test-create-spring
 


### PR DESCRIPTION
This is a temporary change so we can debug which git credentials are being used.