### PR TITLE
chore: Keep retrying if the application URL is "1/1"

### DIFF
--- a/test/helpers/test.go
+++ b/test/helpers/test.go
@@ -319,10 +319,6 @@ func (t *TestOptions) TheApplicationIsRunning(statusCode int, environment string
 		if u == "" {
 			return fmt.Errorf("no URL found for environment %s has app: %#v", environment, applications)
 		}
-		if u == "1/1" {
-			utils.LogInfof("failed to parse application URL: Output of jx %s was %s. Parsed applications map is %v`\n", argsStr, out, applications)
-			return fmt.Errorf("Application URL is 1/1 for %s in env %s", applicationName, environment)
-		}
 		utils.LogInfof("still looking for application %s in env %s\n", applicationName, environment)
 		return nil
 	}

--- a/test/helpers/test.go
+++ b/test/helpers/test.go
@@ -80,7 +80,7 @@ var (
 	TimeoutProwActionWait = utils.GetTimeoutFromEnv("BDD_TIMEOUT_PROW_ACTION_WAIT", 5)
 
 	// EnableChatOpsTests turns on the chatops tests when specified as true
-	EnableChatOpsTests = utils.GetEnv("JX_ENABLE_TEST_CHATOPS_COMMANDS", "false")
+	EnableChatOpsTests = utils.GetEnv("BDD_ENABLE_TEST_CHATOPS_COMMANDS", "false")
 )
 
 // TestOptions is the base testing object

--- a/test/helpers/test.go
+++ b/test/helpers/test.go
@@ -319,6 +319,10 @@ func (t *TestOptions) TheApplicationIsRunning(statusCode int, environment string
 		if u == "" {
 			return fmt.Errorf("no URL found for environment %s has app: %#v", environment, applications)
 		}
+		if u == "1/1" {
+			utils.LogInfof("failed to parse application URL: Output of jx %s was %s. Parsed applications map is %v`\n", argsStr, out, applications)
+			return fmt.Errorf("Application URL is 1/1 for %s in env %s", applicationName, environment)
+		}
 		utils.LogInfof("still looking for application %s in env %s\n", applicationName, environment)
 		return nil
 	}

--- a/test/utils/parsers/get_applications_parser.go
+++ b/test/utils/parsers/get_applications_parser.go
@@ -19,10 +19,13 @@ func ParseJxGetApplications(s string) (map[string]Application, error) {
 	answer := make(map[string]Application, 0)
 	lines := strings.Split(strings.TrimSpace(s), "\n")
 	headerFound := false
+	fieldCount := 3
 	for _, line := range lines {
 		// Ignore any output before the header
 		if strings.HasPrefix(line, "APPLICATION") {
 			headerFound = true
+			headers := strings.Fields(strings.TrimSpace(line))
+			fieldCount = len(headers)
 			continue
 		}
 		if !headerFound {
@@ -30,8 +33,8 @@ func ParseJxGetApplications(s string) (map[string]Application, error) {
 		}
 		line = strings.TrimSpace(line)
 		fields := strings.Fields(line)
-		if len(fields) < 3 {
-			return nil, errors.Errorf("must be at least 3 fields in %s, entire output was %s", line, s)
+		if len(fields) < fieldCount {
+			return nil, errors.Errorf("must be at least %d fields in %s, entire output was %s", fieldCount, line, s)
 		}
 		var desiredPods, runningPods int
 		if len(fields) == 4 {


### PR DESCRIPTION
I see this show up once in a while in BDD tests, resulting in:

```
      Unexpected error:
          <*url.Error | 0xc000264030>: {
              Op: "Get",
              URL: "1/1",
              Err: {
                  what: "unsupported protocol scheme",
                  str: "",
              },
          }
          Get 1/1: unsupported protocol scheme ""
      occurred
```

So let's try to deal with that by both logging the full output when
this happens, and retrying.

Signed-off-by: Andrew Bayer <andrew.bayer@gmail.com>