### PR TITLE
fix: Gitlab merge request URL format has changed

### DIFF
--- a/test/utils/parsers/create_pull_request_parser.go
+++ b/test/utils/parsers/create_pull_request_parser.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 )
 
-var createPullRequestOutputRegex = regexp.MustCompile(`^https:\/\/([^\/]*)\/(?:projects\/)?([^\/]*)\/(?:repos\/)?([^\/]*)\/(?:pull|pull-requests|merge_requests)\/([0-9]*)$`)
+var createPullRequestOutputRegex = regexp.MustCompile(`^https:\/\/([^\/]*)\/(?:projects\/)?([^\/]*)\/(?:repos\/)?([^\/]*)\/(?:-\/)?(?:pull|pull-requests|merge_requests)\/([0-9]*)$`)
 
 type CreatePullRequest struct {
 	Provider          string


### PR DESCRIPTION
It's like
`https://gitlab.com/jxbdd/bdd-spring-1580224566/-/merge_requests/1`
now - that `-/` is throwing things off here. Handling inside jx proper
is just fine, it's only the parsing in `ParseJxCreatePullRequest` here
that's failing.

fixes https://github.com/jenkins-x/jx/issues/6618

Signed-off-by: Andrew Bayer <andrew.bayer@gmail.com>