### PR TITLE
fix: Allow disabling PipelineActivity update check

### DIFF
--- a/test/helpers/suite.go
+++ b/test/helpers/suite.go
@@ -139,6 +139,10 @@ func ensureConfiguration() error {
 	if EnableChatOpsTests == "true" {
 		enableChatOpsTestLogStr = "is set. ChatOps tests will be run as part of quickstart tests"
 	}
+	disablePACheckStr := "is not set. PipelineActivity update tests will be run as part of PR-related tests. If you would like to not run those tests, set this variable to TRUE"
+	if DisablePipelineActivityCheck == "true" {
+		disablePACheckStr = "is set. PipelineActivity update tests will NOT be run as part of PR-related tests"
+	}
 	includeAppsStr := os.Getenv("JX_BDD_INCLUDE_APPS")
 	includeApps := "is not set"
 	if includeAppsStr != "" {
@@ -192,8 +196,9 @@ func ensureConfiguration() error {
 	utils.LogInfof("JX_DISABLE_DELETE_APP:                              %s\n", disableDeleteApp)
 	utils.LogInfof("JX_DISABLE_DELETE_REPO:                             %s\n", disableDeleteRepo)
 	utils.LogInfof("JX_DISABLE_WAIT_FOR_FIRST_RELEASE:                  %s\n", disableWaitForFirstRelease)
-	utils.LogInfof("JX_ENABLE_TEST_CHATOPS_COMMANDS:                    %s\n", enableChatOpsTestLogStr)
+	utils.LogInfof("BDD_ENABLE_TEST_CHATOPS_COMMANDS:                   %s\n", enableChatOpsTestLogStr)
 	utils.LogInfof("JX_BDD_INCLUDE_APPS:                                %s\n", includeApps)
+	utils.LogInfof("BDD_DISABLE_PIPELINEACTIVITY_CHECK:                 %s\n", disablePACheckStr)
 	utils.LogInfof("BDD_TIMEOUT_BUILD_COMPLETES timeout value:          %s\n", os.Getenv("BDD_TIMEOUT_BUILD_COMPLETES"))
 	utils.LogInfof("BDD_TIMEOUT_BUILD_RUNNING_IN_STAGING timeout value: %s\n", os.Getenv("BDD_TIMEOUT_BUILD_RUNNING_IN_STAGING"))
 	utils.LogInfof("BDD_TIMEOUT_URL_RETURNS timeout value:              %s\n", os.Getenv("BDD_TIMEOUT_URL_RETURNS"))


### PR DESCRIPTION
Specifically for use with static master BDD tests. Also cleans up some
debug logging I forgot to delete.

Signed-off-by: Andrew Bayer <andrew.bayer@gmail.com>