### PR TITLE
fix: Tide should be merging PRs we have been merging manually in tests

### DIFF
--- a/jx/bdd/jx-requirements.yml
+++ b/jx/bdd/jx-requirements.yml
@@ -1,6 +1,6 @@
 cluster:
   clusterName: bdd-jx-bdd
-  environmentGitOwner: jenkins-x-bot-test
+  environmentGitOwner: jenkins-x-versions-bot-test
   project: jenkins-x-bdd3
   provider: gke
   zone: europe-west1-c

--- a/jx/bdd/jx-requirements.yml
+++ b/jx/bdd/jx-requirements.yml
@@ -14,6 +14,7 @@ environments:
   - key: production
     owner: ""
     repository: ""
+gitops: true
 ingress:
   domain: ""
   externalDNS: false

--- a/jx/bdd/parameters.yaml
+++ b/jx/bdd/parameters.yaml
@@ -6,5 +6,5 @@ gpg: {}
 pipelineUser:
   github:
     host: github.com
-    username: jenkins-x-bot-test
+    username: jenkins-x-versions-bot-test
     email: jenkins-x@googlegroups.com

--- a/test/helpers/test.go
+++ b/test/helpers/test.go
@@ -247,7 +247,7 @@ func (t *TestOptions) GitOpsEnabled() bool {
 
 // NextBuildNumber returns the next build number for a given repo by looking at the SourceRepository CRD.
 func (t *TestOptions) NextBuildNumber(repo *gits.GitRepository) string {
-	crd := fmt.Sprintf("%s-%s", repo.Organisation, repo.Name)
+	crd := strings.ToLower(fmt.Sprintf("%s-%s", repo.Organisation, repo.Name))
 
 	args := []string{"get", "sourcerepository", crd, "-o", "json"}
 	command := exec.Command("kubectl", args...)

--- a/test/suite/apps/ui.go
+++ b/test/suite/apps/ui.go
@@ -3,6 +3,12 @@ package apps
 import (
 	"context"
 	"fmt"
+	"io/ioutil"
+	"net/http"
+	"os"
+	"os/exec"
+	"strconv"
+
 	"github.com/google/go-github/v28/github"
 	"github.com/jenkins-x/bdd-jx/test/helpers"
 	"github.com/jenkins-x/bdd-jx/test/utils"
@@ -11,11 +17,6 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"github.com/onsi/gomega/gexec"
-	"io/ioutil"
-	"net/http"
-	"os"
-	"os/exec"
-	"strconv"
 )
 
 var _ = Describe("Jenkins X UI tests", func() {
@@ -76,6 +77,8 @@ func (t *AppTestOptions) UITest() bool {
 
 	return Context("UI", func() {
 		var uiURL = ""
+		var addAppJobName string
+		var deleteAppJobName string
 		It("ensure UI is not installed", func() {
 			pr, err := t.GetPullRequestWithTitle(gitHubClient, ctx, gitInfo.Organisation, gitInfo.Name, fmt.Sprintf("Add %s %s", uiAppName, uiAppVersion))
 			Expect(err).ShouldNot(HaveOccurred())
@@ -84,22 +87,14 @@ func (t *AppTestOptions) UITest() bool {
 
 		It("install UI via 'jx add app'", func() {
 			By("installing the app")
-			args := []string{"add", "app", uiAppName, "--version", uiAppVersion, "--repository=https://charts.cloudbees.com/cjxd/cloudbees"}
-			t.ExpectJxExecution(t.WorkDir, timeoutAppTests, 0, args...)
+			addAppJobName = fmt.Sprintf("%s/%s/master #%s", gitInfo.Organisation, gitInfo.Name, t.NextBuildNumber(gitInfo))
+			args := []string{"add", "app", uiAppName, "--version", uiAppVersion, "--repository=https://charts.cloudbees.com/cjxd/cloudbees", "--auto-merge"}
+			out := t.ExpectJxExecutionWithOutput(t.WorkDir, timeoutAppTests, 0, args...)
 
-			pr, err := t.GetPullRequestWithTitle(gitHubClient, ctx, gitInfo.Organisation, gitInfo.Name, fmt.Sprintf("Add %s %s", uiAppName, uiAppVersion))
-			Expect(err).ShouldNot(HaveOccurred())
-			Expect(pr).ShouldNot(BeNil())
-			Expect(*pr.State).Should(Equal("open"))
-
-			By("merging the install app PR")
-			results, _, err := gitHubClient.PullRequests.Merge(ctx, gitInfo.Organisation, gitInfo.Name, *pr.Number, "PR merge", nil)
-			Expect(pr).ShouldNot(BeNil())
-			Expect(*results.Merged).Should(BeTrue())
+			t.WaitForCreatedPRToMerge(gitHubClient, ctx, out)
 
 			By("waiting for the build to complete")
-			jobName := fmt.Sprintf("%s/%s/master #%s", gitInfo.Organisation, gitInfo.Name, t.NextBuildNumber(gitInfo))
-			t.TailBuildLog(jobName, helpers.TimeoutBuildCompletes)
+			t.TailBuildLog(addAppJobName, helpers.TimeoutBuildCompletes)
 		})
 
 		It("ensure UI is installed", func() {
@@ -149,21 +144,14 @@ func (t *AppTestOptions) UITest() bool {
 		})
 
 		It("uninstall UI", func() {
-			args := []string{"delete", "app", uiAppName}
-			t.ExpectJxExecution(t.WorkDir, timeoutAppTests, 0, args...)
+			deleteAppJobName = fmt.Sprintf("%s/%s/master #%s", gitInfo.Organisation, gitInfo.Name, t.NextBuildNumber(gitInfo))
+			args := []string{"delete", "app", uiAppName, "--auto-merge"}
+			out := t.ExpectJxExecutionWithOutput(t.WorkDir, timeoutAppTests, 0, args...)
 
-			pr, err := t.GetPullRequestWithTitle(gitHubClient, ctx, gitInfo.Organisation, gitInfo.Name, fmt.Sprintf("Delete %s", uiAppName))
-			Expect(err).ShouldNot(HaveOccurred())
-			Expect(pr).ShouldNot(BeNil())
-
-			By("merging the uninstall app PR")
-			results, _, err := gitHubClient.PullRequests.Merge(ctx, gitInfo.Organisation, gitInfo.Name, *pr.Number, "PR merge", nil)
-			Expect(pr).ShouldNot(BeNil())
-			Expect(*results.Merged).Should(BeTrue())
+			t.WaitForCreatedPRToMerge(gitHubClient, ctx, out)
 
 			By("waiting for the build to complete")
-			jobName := fmt.Sprintf("%s/%s/master #%s", gitInfo.Organisation, gitInfo.Name, t.NextBuildNumber(gitInfo))
-			t.TailBuildLog(jobName, helpers.TimeoutBuildCompletes)
+			t.TailBuildLog(deleteAppJobName, helpers.TimeoutBuildCompletes)
 		})
 	})
 }


### PR DESCRIPTION
I've tested this with `test-app-lifecycle` and it worked, so hopefully I didn't do something magic in my test environment. =)

Ideally, I'd like to do this with the upgrade boot test too, but I'll come back to that - there's no `--auto-merge` flag there, so it would need to have a `/approve` added, which may not work quite right with the bot user. I'll loop back on that.

fixes https://github.com/jenkins-x/jx/issues/6850