### PR TITLE
fix: Add Lighthouse/Prow test for retest and override

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,10 @@ clean:
 build:
 	$(GO) build $(BUILDFLAGS) ./test/...
 
-.PHONY: clean test build fmt
+build-all:
+	$(GO) test -run=nope -failfast -short ./test/...
+
+.PHONY: clean test build fmt build-all
 
 ### LEGACY TARGETS, use go test when running locally ###
 
@@ -73,6 +76,9 @@ test-devpod:
 
 test-jxui:
 	$(GO) test $(TESTFLAGS) ./test/suite/jxui
+
+test-lighthouse:
+	$(GO) test $(TESTFLAGS) ./test/suite/lighthouse
 
 #targets for individual quickstarts
 test-quickstart-golang-http:

--- a/go.sum
+++ b/go.sum
@@ -842,6 +842,7 @@ github.com/stretchr/testify v1.2.1/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXf
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0 h1:TivCn/peBQ7UY8ooIcPgZFpTNSz0Q2U6UrFlUfqbe0Q=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
+github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJyk=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/tektoncd/pipeline v0.0.0-20190327171839-7c43fbae2816 h1:mVXUfrlHARAl+q57b78x3wb5TKwU4QwGoB2a9My5eiw=
 github.com/tektoncd/pipeline v0.0.0-20190327171839-7c43fbae2816/go.mod h1:IZzJdiX9EqEMuUcgdnElozdYYRh0/ZRC+NKMLj1K3Yw=

--- a/test/suite/lighthouse/helpers.go
+++ b/test/suite/lighthouse/helpers.go
@@ -30,7 +30,7 @@ pipelineConfig:
       - pipeline: pullRequest
         name: make-linux
         step:
-          sh: sleep 60 && exit 1
+          sh: sleep 15 && exit 1
 `
 )
 

--- a/test/suite/lighthouse/helpers.go
+++ b/test/suite/lighthouse/helpers.go
@@ -1,0 +1,230 @@
+package lighthouse
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/jenkins-x/bdd-jx/test/helpers"
+
+	"github.com/jenkins-x/bdd-jx/test/utils"
+	"github.com/jenkins-x/jx/pkg/gits"
+	"github.com/jenkins-x/jx/pkg/util"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+const (
+	defaultContext    = "pr-build"
+	lhQuickstart      = "golang-http"
+	brokenJenkinsXYml = `buildPack: go
+pipelineConfig:
+  pipelines:
+    overrides:
+      # Replace make-build on pullRequest in any stage/lifecycle with "exit 1" so the pipeline will fail.
+      - pipeline: pullRequest
+        name: make-linux
+        step:
+          sh: sleep 60 && exit 1
+`
+)
+
+var _ = ChatOpsTests()
+
+func ChatOpsTests() bool {
+	return Describe("Lighthouse ChatOps", func() {
+		var (
+			T                helpers.TestOptions
+			err              error
+			provider         gits.GitProvider
+			approverProvider gits.GitProvider
+		)
+
+		BeforeEach(func() {
+			provider, err = T.GetGitProvider()
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(provider).ShouldNot(BeNil())
+
+			approverProvider, err = T.GetApproverGitProvider()
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(approverProvider).ShouldNot(BeNil())
+
+			qsNameParts := strings.Split(lhQuickstart, "-")
+			qsAbbr := ""
+			for s := range qsNameParts {
+				qsAbbr = qsAbbr + qsNameParts[s][:1]
+
+			}
+			applicationName := helpers.TempDirPrefix + qsAbbr + "-" + strconv.FormatInt(GinkgoRandomSeed(), 10)
+			T = helpers.TestOptions{
+				ApplicationName: applicationName,
+				WorkDir:         helpers.WorkDir,
+			}
+			T.GitProviderURL()
+
+			utils.LogInfof("Creating application %s in dir %s\n", util.ColorInfo(applicationName), util.ColorInfo(helpers.WorkDir))
+		})
+
+		Describe("Create a quickstart", func() {
+			Context(fmt.Sprintf("by running jx create quickstart %s", lhQuickstart), func() {
+				It("creates a new source repository", func() {
+					args := []string{"create", "quickstart", "-b", "--org", T.GetGitOrganisation(), "-p", T.ApplicationName, "-f", lhQuickstart}
+
+					gitProviderUrl, err := T.GitProviderURL()
+					Expect(err).NotTo(HaveOccurred())
+					if gitProviderUrl != "" {
+						utils.LogInfof("Using Git provider URL %s\n", gitProviderUrl)
+						args = append(args, "--git-provider-url", gitProviderUrl)
+					}
+					argsStr := strings.Join(args, " ")
+					By(fmt.Sprintf("calling jx %s", argsStr), func() {
+						T.ExpectJxExecution(T.WorkDir, helpers.TimeoutSessionWait, 0, args...)
+					})
+
+					By("adding the approver to OWNERS", func() {
+						createdPR := T.CreatePullRequestWithLocalChange(fmt.Sprintf("Adding %s to OWNERS", helpers.PullRequestApproverUsername), func(workDir string) {
+							// overwrite the existing OWNERS with a new one containing the approver user
+							fileName := "OWNERS"
+							owners := filepath.Join(workDir, fileName)
+
+							data := []byte(fmt.Sprintf("approvers:\n- %s\n- %s\nreviewers:\n- %s\n- %s\n",
+								provider.UserAuth().Username, helpers.PullRequestApproverUsername,
+								provider.UserAuth().Username, helpers.PullRequestApproverUsername))
+							err := ioutil.WriteFile(owners, data, util.DefaultWritePermissions)
+							if err != nil {
+								panic(err)
+							}
+
+							T.ExpectCommandExecution(workDir, time.Minute, 0, "git", "add", fileName)
+						})
+
+						ownersPR, err := T.GetPullRequestByNumber(provider, createdPR.Owner, createdPR.Repository, createdPR.PullRequestNumber)
+						Expect(err).NotTo(HaveOccurred())
+						Expect(ownersPR).ShouldNot(BeNil())
+
+						By("merging the OWNERS PR")
+						err = provider.MergePullRequest(ownersPR, "PR merge")
+						Expect(err).ShouldNot(HaveOccurred())
+
+						T.WaitForPullRequestToMerge(provider, ownersPR.Owner, ownersPR.Repo, *ownersPR.Number, ownersPR.URL)
+					})
+
+					prTitle := "My First PR commit"
+					var pr *gits.GitPullRequest
+					By("performing a pull request on the source and making sure it fails", func() {
+						createdPR := T.CreatePullRequestWithLocalChange(prTitle, func(workDir string) {
+							// overwrite the existing jenkins-x.yml with a failing one
+							fileName := "jenkins-x.yml"
+							jxYml := filepath.Join(workDir, fileName)
+
+							data := []byte(brokenJenkinsXYml)
+							err := ioutil.WriteFile(jxYml, data, util.DefaultWritePermissions)
+							if err != nil {
+								panic(err)
+							}
+
+							T.ExpectCommandExecution(workDir, time.Minute, 0, "git", "add", fileName)
+						})
+
+						pr, err = T.GetPullRequestByNumber(provider, createdPR.Owner, createdPR.Repository, createdPR.PullRequestNumber)
+						Expect(err).NotTo(HaveOccurred())
+						Expect(pr).ShouldNot(BeNil())
+
+						T.WaitForPullRequestCommitStatus(provider, pr, "failure", []string{defaultContext})
+					})
+
+					By("attempting to LGTM our own PR", func() {
+						err = T.AttemptToLGTMOwnPullRequest(provider, pr)
+						Expect(err).NotTo(HaveOccurred())
+					})
+
+					By("adding a hold label", func() {
+						err = T.AddHoldLabelToPullRequestWithChatOpsCommand(provider, pr)
+						Expect(err).NotTo(HaveOccurred())
+					})
+
+					By("adding a WIP label", func() {
+						err = T.AddWIPLabelToPullRequestByUpdatingTitle(provider, pr)
+						Expect(err).NotTo(HaveOccurred())
+					})
+
+					By("approving pull request", func() {
+						err = T.ApprovePullRequest(provider, approverProvider, pr)
+						Expect(err).ShouldNot(HaveOccurred())
+					})
+
+					// '/retest' and '/test this' need to be done by a user other than the bot, as best as I can tell. (APB)
+
+					By("retest failed context with it failing again", func() {
+						err = approverProvider.AddPRComment(pr, "/retest")
+						Expect(err).ShouldNot(HaveOccurred())
+
+						// Wait until we see a pending status, meaning we've got a new build
+						T.WaitForPullRequestCommitStatus(provider, pr, "pending", []string{defaultContext})
+
+						// Wait until we see the build fail.
+						T.WaitForPullRequestCommitStatus(provider, pr, "failure", []string{defaultContext})
+					})
+
+					By("'/test this' with it failing again", func() {
+						err = approverProvider.AddPRComment(pr, "/test this")
+						Expect(err).ShouldNot(HaveOccurred())
+
+						// Wait until we see a pending status, meaning we've got a new build
+						T.WaitForPullRequestCommitStatus(provider, pr, "pending", []string{defaultContext})
+
+						// Wait until we see the build fail.
+						T.WaitForPullRequestCommitStatus(provider, pr, "failure", []string{defaultContext})
+					})
+
+					// '/override' has to be done by a repo admin, so use the bot user.
+
+					By("override failed context, see status as success, wait for it to merge", func() {
+						err = provider.AddPRComment(pr, fmt.Sprintf("/override %s", defaultContext))
+						Expect(err).ShouldNot(HaveOccurred())
+
+						// Wait until we see a success status
+						T.WaitForPullRequestCommitStatus(provider, pr, "success", []string{defaultContext})
+
+						T.WaitForPullRequestToMerge(provider, pr.Owner, pr.Repo, *pr.Number, pr.URL)
+					})
+
+					// TODO: Later: add multiple contexts, one more required, one more optional
+
+					By("creating an issue and assigning it to a valid user", func() {
+						issue := &gits.GitIssue{
+							Owner: T.GetGitOrganisation(),
+							Repo:  T.GetApplicationName(),
+							Title: "Test the /assign command",
+							Body:  "This tests assigning a user using a ChatOps command",
+						}
+						err = T.CreateIssueAndAssignToUserWithChatOpsCommand(issue, provider)
+						Expect(err).NotTo(HaveOccurred())
+					})
+
+					if T.DeleteApplications() {
+						args = []string{"delete", "application", "-b", T.ApplicationName}
+						argsStr := strings.Join(args, " ")
+						By(fmt.Sprintf("calling %s to delete the application", argsStr), func() {
+							T.ExpectJxExecution(T.WorkDir, helpers.TimeoutSessionWait, 0, args...)
+						})
+					}
+
+					if T.DeleteRepos() {
+						args = []string{"delete", "repo", "-b", "--github", "-o", T.GetGitOrganisation(), "-n", T.ApplicationName}
+						argsStr = strings.Join(args, " ")
+
+						By(fmt.Sprintf("calling %s to delete the repository", os.Args), func() {
+							T.ExpectJxExecution(T.WorkDir, helpers.TimeoutSessionWait, 0, args...)
+						})
+					}
+				})
+			})
+		})
+	})
+}

--- a/test/suite/lighthouse/lighthouse_test.go
+++ b/test/suite/lighthouse/lighthouse_test.go
@@ -1,0 +1,17 @@
+package lighthouse_test
+
+import (
+	"testing"
+
+	"github.com/jenkins-x/bdd-jx/test/helpers"
+
+	. "github.com/onsi/ginkgo"
+)
+
+func TestSuite(t *testing.T) {
+	helpers.RunWithReporters(t, "lighthouse")
+}
+
+var _ = BeforeSuite(helpers.BeforeSuiteCallback)
+
+var _ = SynchronizedAfterSuite(func() {}, helpers.SynchronizedAfterSuiteCallback)

--- a/test/suite/quickstart/helpers.go
+++ b/test/suite/quickstart/helpers.go
@@ -13,7 +13,6 @@ import (
 	"github.com/jenkins-x/bdd-jx/test/helpers"
 
 	"github.com/jenkins-x/bdd-jx/test/utils"
-	"github.com/jenkins-x/jx/pkg/gits"
 	"github.com/jenkins-x/jx/pkg/util"
 
 	. "github.com/onsi/ginkgo"
@@ -102,36 +101,6 @@ func createQuickstartTests(quickstartName string) bool {
 						if T.TestPullRequest() {
 							By("performing a pull request on the source and asserting that a preview environment is created", func() {
 								T.CreatePullRequestAndGetPreviewEnvironment(200)
-							})
-						}
-
-						if T.WeShouldTestChatOpsCommands() {
-							gitProvider, err := T.GetGitProvider()
-							Expect(err).NotTo(HaveOccurred())
-							By("creating an issue and assigning it to a valid user", func() {
-								issue := &gits.GitIssue{
-									Owner: owner,
-									Repo:  applicationName,
-									Title: "Test the /assign command",
-									Body:  "This tests assigning a user using a ChatOps command",
-								}
-								err = T.CreateIssueAndAssignToUserWithChatOpsCommand(issue, gitProvider)
-								Expect(err).NotTo(HaveOccurred())
-							})
-
-							By("attempting to LGTM our own PR", func() {
-								err = T.AttemptToLGTMOwnPullRequest(gitProvider, owner, applicationName)
-								Expect(err).NotTo(HaveOccurred())
-							})
-
-							By("adding a hold label", func() {
-								err = T.AddHoldLabelToPullRequestWithChatOpsCommand(gitProvider, owner, applicationName)
-								Expect(err).NotTo(HaveOccurred())
-							})
-
-							By("adding a WIP label", func() {
-								err = T.AddWIPLabelToPullRequestByUpdatingTitle(gitProvider, owner, applicationName)
-								Expect(err).NotTo(HaveOccurred())
 							})
 						}
 					} else {


### PR DESCRIPTION
I also moved the existing chatops tests to the new `test/suites/lighthouse/helpers.go` to centralize the LH/chatops tests, and I'll eventually add more tests to this for multiple contexts, both required and optional, but this is a start.


I'm validating the new `test-lighthouse` target on the `github` context on https://github.com/jenkins-x/lighthouse/pull/578

fixes https://github.com/jenkins-x/jx/issues/6862
