### PR TITLE
fix: Get Lighthouse tests to work on GitLab

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/google/go-github/v28 v28.1.1
 	github.com/jenkins-x/go-scm v1.5.90
 	github.com/jenkins-x/golang-jenkins v0.0.0-20180919102630-65b83ad42314
-	github.com/jenkins-x/jx v0.0.0-20200429072337-ecafbe2d3ce6
+	github.com/jenkins-x/jx v0.0.0-20200430140330-6b8cc53d0962
 	github.com/onsi/ginkgo v1.8.0
 	github.com/onsi/gomega v1.5.0
 	github.com/pkg/errors v0.8.1

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/google/go-github/v28 v28.1.1
 	github.com/jenkins-x/go-scm v1.5.90
 	github.com/jenkins-x/golang-jenkins v0.0.0-20180919102630-65b83ad42314
-	github.com/jenkins-x/jx v0.0.0-20200428172844-e2bf23f9b390
+	github.com/jenkins-x/jx v0.0.0-20200429072337-ecafbe2d3ce6
 	github.com/onsi/ginkgo v1.8.0
 	github.com/onsi/gomega v1.5.0
 	github.com/pkg/errors v0.8.1

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/google/go-github/v28 v28.1.1
 	github.com/jenkins-x/go-scm v1.5.90
 	github.com/jenkins-x/golang-jenkins v0.0.0-20180919102630-65b83ad42314
-	github.com/jenkins-x/jx v0.0.0-20200413182250-109f0011927c
+	github.com/jenkins-x/jx v0.0.0-20200428172844-e2bf23f9b390
 	github.com/onsi/ginkgo v1.8.0
 	github.com/onsi/gomega v1.5.0
 	github.com/pkg/errors v0.8.1

--- a/go.sum
+++ b/go.sum
@@ -403,10 +403,8 @@ github.com/jenkins-x/go-scm v1.5.90 h1:8XWoYB8xnszRhqDJcEwr8Z/c71Jk5CKuMNZWsmX47
 github.com/jenkins-x/go-scm v1.5.90/go.mod h1:PCT338UhP/pQ0IeEeMEf/hoLTYKcH7qjGEKd7jPkeYg=
 github.com/jenkins-x/golang-jenkins v0.0.0-20180919102630-65b83ad42314 h1:kyBMx/ucSV92S+umX/V6DDaPNynlFFOM9MGJWApltoU=
 github.com/jenkins-x/golang-jenkins v0.0.0-20180919102630-65b83ad42314/go.mod h1:C6j5HgwlHGjRU27W4XCs6jXksqYFo8OdBu+p44jqQeM=
-github.com/jenkins-x/jx v0.0.0-20200413182250-109f0011927c h1:T/0yDxfeerBv2btNrIFTtlJdgdr9al/UNgvEaeRhqtw=
-github.com/jenkins-x/jx v0.0.0-20200413182250-109f0011927c/go.mod h1:1rj7aDeo0CG4Wg6vzFsslR843L692yr5F6Bg+wW5Njs=
-github.com/jenkins-x/jx v0.0.0-20200428172844-e2bf23f9b390 h1:9nEGaCHSdFAN2EP8wK4xU5KOhchxUzCMPl1RvcJ3FPA=
-github.com/jenkins-x/jx v0.0.0-20200428172844-e2bf23f9b390/go.mod h1:AJ/IR1nGGbDLePNIxD0X9yiGGmlIJDB7+OuiBcT+KHo=
+github.com/jenkins-x/jx v0.0.0-20200429072337-ecafbe2d3ce6 h1:SIQWyvWo0UNqEHo6VrwDQFdlzi7l0Ymm7xlSGWul2uI=
+github.com/jenkins-x/jx v0.0.0-20200429072337-ecafbe2d3ce6/go.mod h1:AJ/IR1nGGbDLePNIxD0X9yiGGmlIJDB7+OuiBcT+KHo=
 github.com/jenkins-x/sonobuoy v0.11.7-0.20190318120422-253758214767 h1:lKtC9uHyWi8wd+EUch3Pfzk3/8XSJvYRJhvk9dK4YKY=
 github.com/jenkins-x/sonobuoy v0.11.7-0.20190318120422-253758214767/go.mod h1:UR3AoCKJHHKi2AoOWeFbZcMKyd5LqQkdCRgwqZkX/io=
 github.com/jessevdk/go-flags v1.4.0/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJSGM75WSRxI=

--- a/go.sum
+++ b/go.sum
@@ -405,6 +405,8 @@ github.com/jenkins-x/golang-jenkins v0.0.0-20180919102630-65b83ad42314 h1:kyBMx/
 github.com/jenkins-x/golang-jenkins v0.0.0-20180919102630-65b83ad42314/go.mod h1:C6j5HgwlHGjRU27W4XCs6jXksqYFo8OdBu+p44jqQeM=
 github.com/jenkins-x/jx v0.0.0-20200413182250-109f0011927c h1:T/0yDxfeerBv2btNrIFTtlJdgdr9al/UNgvEaeRhqtw=
 github.com/jenkins-x/jx v0.0.0-20200413182250-109f0011927c/go.mod h1:1rj7aDeo0CG4Wg6vzFsslR843L692yr5F6Bg+wW5Njs=
+github.com/jenkins-x/jx v0.0.0-20200428172844-e2bf23f9b390 h1:9nEGaCHSdFAN2EP8wK4xU5KOhchxUzCMPl1RvcJ3FPA=
+github.com/jenkins-x/jx v0.0.0-20200428172844-e2bf23f9b390/go.mod h1:AJ/IR1nGGbDLePNIxD0X9yiGGmlIJDB7+OuiBcT+KHo=
 github.com/jenkins-x/sonobuoy v0.11.7-0.20190318120422-253758214767 h1:lKtC9uHyWi8wd+EUch3Pfzk3/8XSJvYRJhvk9dK4YKY=
 github.com/jenkins-x/sonobuoy v0.11.7-0.20190318120422-253758214767/go.mod h1:UR3AoCKJHHKi2AoOWeFbZcMKyd5LqQkdCRgwqZkX/io=
 github.com/jessevdk/go-flags v1.4.0/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJSGM75WSRxI=

--- a/go.sum
+++ b/go.sum
@@ -405,6 +405,8 @@ github.com/jenkins-x/golang-jenkins v0.0.0-20180919102630-65b83ad42314 h1:kyBMx/
 github.com/jenkins-x/golang-jenkins v0.0.0-20180919102630-65b83ad42314/go.mod h1:C6j5HgwlHGjRU27W4XCs6jXksqYFo8OdBu+p44jqQeM=
 github.com/jenkins-x/jx v0.0.0-20200429072337-ecafbe2d3ce6 h1:SIQWyvWo0UNqEHo6VrwDQFdlzi7l0Ymm7xlSGWul2uI=
 github.com/jenkins-x/jx v0.0.0-20200429072337-ecafbe2d3ce6/go.mod h1:AJ/IR1nGGbDLePNIxD0X9yiGGmlIJDB7+OuiBcT+KHo=
+github.com/jenkins-x/jx v0.0.0-20200430140330-6b8cc53d0962 h1:FFqZbag/jJNHPgaROy8vz3wI+FRjtAmoLiK0+M/ScIw=
+github.com/jenkins-x/jx v0.0.0-20200430140330-6b8cc53d0962/go.mod h1:AJ/IR1nGGbDLePNIxD0X9yiGGmlIJDB7+OuiBcT+KHo=
 github.com/jenkins-x/sonobuoy v0.11.7-0.20190318120422-253758214767 h1:lKtC9uHyWi8wd+EUch3Pfzk3/8XSJvYRJhvk9dK4YKY=
 github.com/jenkins-x/sonobuoy v0.11.7-0.20190318120422-253758214767/go.mod h1:UR3AoCKJHHKi2AoOWeFbZcMKyd5LqQkdCRgwqZkX/io=
 github.com/jessevdk/go-flags v1.4.0/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJSGM75WSRxI=

--- a/jx/bdd/ci.sh
+++ b/jx/bdd/ci.sh
@@ -73,8 +73,6 @@ jx step bdd \
     --no-delete-app \
     --no-delete-repo \
     --tests install \
-    --tests test-create-spring \
-    --tests test-single-import \
     --tests test-quickstart-golang-http \
     --tests test-app-lifecycle \
     --verbose=true

--- a/test/helpers/test.go
+++ b/test/helpers/test.go
@@ -653,7 +653,7 @@ func (t *TestOptions) ApprovePullRequestFromLogOutput(provider gits.GitProvider,
 	pr, err := provider.GetPullRequest(gitInfo.Organisation, repoStruct, createdPR.PullRequestNumber)
 	Expect(err).ShouldNot(HaveOccurred())
 	Expect(pr).ShouldNot(BeNil())
-	Expect(*pr.State).Should(Equal("open"))
+	Expect(*pr.State).Should(Or(Equal("open"), Equal("opened")))
 
 	By("approving the PR")
 	err = t.ApprovePullRequest(provider, approverProvider, pr)
@@ -664,6 +664,10 @@ func (t *TestOptions) ApprovePullRequestFromLogOutput(provider gits.GitProvider,
 func (t *TestOptions) AddApproverAsCollaborator(provider gits.GitProvider, approverProvider gits.GitProvider, repoOwner string, repoName string) error {
 	err := provider.AddCollaborator(PullRequestApproverUsername, repoOwner, repoName)
 	if err != nil {
+		// Ignore the error and just return if the provider is gitlab and the error contains "Member already exists"
+		if strings.Contains(err.Error(), "Member already exists") {
+			return nil
+		}
 		return err
 	}
 	invites, _, err := approverProvider.ListInvitations()
@@ -696,7 +700,7 @@ func (t *TestOptions) GetPullRequestByNumber(provider gits.GitProvider, repoOwne
 
 // WaitForPullRequestCommitStatus checks a pull request until either it reaches a given status in all the contexts supplied
 // or a timeout is reached.
-func (t *TestOptions) WaitForPullRequestCommitStatus(provider gits.GitProvider, pr *gits.GitPullRequest, desiredStatus string, contexts []string) {
+func (t *TestOptions) WaitForPullRequestCommitStatus(provider gits.GitProvider, pr *gits.GitPullRequest, contexts []string, desiredStatuses ...string) {
 	Expect(pr.LastCommitSha).ShouldNot(Equal(""))
 
 	checkPRStatuses := func() error {
@@ -706,11 +710,21 @@ func (t *TestOptions) WaitForPullRequestCommitStatus(provider gits.GitProvider, 
 			return err
 		}
 		contextStatuses := make(map[string]*gits.GitRepoStatus)
-		for _, status := range statuses {
+		// For GitHub, only set the status if it's the first one we see for the context, which is always the newest
+		// For GitLab, ordering is actually the inverse,
+
+		var orderedStatuses []*gits.GitRepoStatus
+		if provider.Kind() == "gitlab" {
+			for i := len(statuses) - 1; i >= 0; i-- {
+				orderedStatuses = append(orderedStatuses, statuses[i])
+			}
+		} else {
+			orderedStatuses = append(orderedStatuses, statuses...)
+		}
+		for _, status := range orderedStatuses {
 			if status == nil {
 				return err
 			}
-			// Only set the status if it's the first one we see for the context, which is always the newest
 			if _, exists := contextStatuses[status.Context]; !exists {
 				contextStatuses[status.Context] = status
 			}
@@ -723,7 +737,7 @@ func (t *TestOptions) WaitForPullRequestCommitStatus(provider gits.GitProvider, 
 			status, ok := contextStatuses[c]
 			if !ok || status == nil {
 				wrongStatuses = append(wrongStatuses, fmt.Sprintf("%s: missing", c))
-			} else if status.State != desiredStatus {
+			} else if !isADesiredStatus(status.State, desiredStatuses) {
 				wrongStatuses = append(wrongStatuses, fmt.Sprintf("%s: %s", c, status.State))
 			} else {
 				matchedStatus = status
@@ -731,7 +745,7 @@ func (t *TestOptions) WaitForPullRequestCommitStatus(provider gits.GitProvider, 
 		}
 
 		if len(wrongStatuses) > 0 {
-			errMsg := fmt.Sprintf("wrong or missing status for PR %s/%s/%d context(s): %s, expected %s", pr.Owner, pr.Repo, *pr.Number, strings.Join(wrongStatuses, ", "), desiredStatus)
+			errMsg := fmt.Sprintf("wrong or missing status for PR %s/%s/%d context(s): %s, expected %s", pr.Owner, pr.Repo, *pr.Number, strings.Join(wrongStatuses, ", "), strings.Join(desiredStatuses, ","))
 			utils.LogInfof("WARNING: %s\n", errMsg)
 			return errors.New(errMsg)
 		}
@@ -750,8 +764,22 @@ func (t *TestOptions) WaitForPullRequestCommitStatus(provider gits.GitProvider, 
 		return nil
 	}
 
-	err := RetryExponentialBackoff(TimeoutPipelineActivityComplete, checkPRStatuses)
+	exponentialBackOff := backoff.NewExponentialBackOff()
+	exponentialBackOff.MaxElapsedTime = TimeoutPipelineActivityComplete
+	exponentialBackOff.MaxInterval = 10 * time.Second
+	exponentialBackOff.Reset()
+	err := backoff.Retry(checkPRStatuses, exponentialBackOff)
+
 	Expect(err).ShouldNot(HaveOccurred())
+}
+
+func isADesiredStatus(status string, desiredStatuses []string) bool {
+	for _, s := range desiredStatuses {
+		if status == s {
+			return true
+		}
+	}
+	return false
 }
 
 // TailBuildLog tails the logs of the specified job
@@ -821,7 +849,7 @@ func (t *TestOptions) ThereShouldBeAJobThatCompletesSuccessfully(jobName string,
 	return buildNumber
 }
 
-// RetryExponentialBackoff retries the given function up to the maximum duration
+// Retry retries the given function up to the maximum duration
 func Retry(maxDuration time.Duration, f func() error) error {
 	exponentialBackOff := backoff.NewExponentialBackOff()
 	exponentialBackOff.MaxElapsedTime = maxDuration
@@ -1048,7 +1076,6 @@ func (t *TestOptions) ApprovePullRequest(defaultProvider gits.GitProvider, appro
 	if approverProvider.Kind() == "gitlab" {
 		cmd = "lh-" + cmd
 	}
-	utils.LogInfof("COMMAND FOR KIND %s IS: %s\n", approverProvider.Kind(), cmd)
 	err = approverProvider.AddPRComment(pullRequest, fmt.Sprintf("/%s", cmd))
 	if err != nil {
 		return err
@@ -1226,12 +1253,12 @@ func (t *TestOptions) WaitForPullRequestToMerge(provider gits.GitProvider, owner
 	waitForMergeFunc := func() error {
 		pr, err := provider.GetPullRequest(owner, repoStruct, prNumber)
 		if err != nil {
-			utils.LogInfof("WARNING: Error getting pull request: %s", err)
+			utils.LogInfof("WARNING: Error getting pull request: %s\n", err)
 			return err
 		}
 		if pr == nil {
 			err = fmt.Errorf("got a nil PR for %s", prURL)
-			utils.LogInfof("WARNING: %s", err)
+			utils.LogInfof("WARNING: %s\n", err)
 			return err
 		}
 		isMerged := pr.Merged
@@ -1239,7 +1266,7 @@ func (t *TestOptions) WaitForPullRequestToMerge(provider gits.GitProvider, owner
 			return nil
 		} else {
 			err = fmt.Errorf("PR %s not yet merged", prURL)
-			utils.LogInfof("WARNING: %s, sleeping and retrying", err)
+			utils.LogInfof("WARNING: %s, sleeping and retrying\n", err)
 			return err
 		}
 	}

--- a/test/helpers/test.go
+++ b/test/helpers/test.go
@@ -965,11 +965,16 @@ func (t *TestOptions) CreateIssueAndAssignToUserWithChatOpsCommand(issue *gits.G
 
 	utils.LogInfof("created issue with number %d\n", *createdIssue.Number)
 
+	cmd := "assign"
+	// Deal with GitLab hijacking /assign
+	if provider.Kind() == "gitlab" {
+		cmd = "lh-" + cmd
+	}
 	err = provider.CreateIssueComment(
 		issue.Owner,
 		issue.Repo,
 		*createdIssue.Number,
-		fmt.Sprintf("/assign %s", provider.CurrentUsername()),
+		fmt.Sprintf("/%s %s", cmd, provider.CurrentUsername()),
 	)
 	if err != nil {
 		return err
@@ -1039,7 +1044,12 @@ func (t *TestOptions) ApprovePullRequest(defaultProvider gits.GitProvider, appro
 	Expect(err).ShouldNot(HaveOccurred())
 
 	By("approving the PR")
-	err = approverProvider.AddPRComment(pullRequest, "/approve")
+	cmd := "approve"
+	if approverProvider.Kind() == "gitlab" {
+		cmd = "lh-" + cmd
+	}
+	utils.LogInfof("COMMAND FOR KIND %s IS: %s\n", approverProvider.Kind(), cmd)
+	err = approverProvider.AddPRComment(pullRequest, fmt.Sprintf("/%s", cmd))
 	if err != nil {
 		return err
 	}

--- a/test/suite/saas/jx_saas.go
+++ b/test/suite/saas/jx_saas.go
@@ -63,7 +63,7 @@ func (t *testCaseSaas) expectAllPodsNotInState(phase v1.PodPhase) {
 	pods, err := t.kubeClient.CoreV1().Pods(t.namespace).List(listOptions)
 	Expect(err).NotTo(HaveOccurred())
 	for _, pod := range pods.Items {
-		if !strings.Contains(pod.Labels["job-name"],"jx-boot") {
+		if !strings.Contains(pod.Labels["job-name"], "jx-boot") {
 			Expect(pod.Status.Phase).NotTo(Equal(phase), fmt.Sprintf("pod %s is in phase %s", pod.Name, pod.Status.Phase))
 		}
 	}


### PR DESCRIPTION
Required some changes in jx, disabling a couple things if GitLab, and using `/lh-approve` and `/lh-assign` instead of `/approve` and `/assign` to sneak around GitLab quick actions hijacking.

Signed-off-by: Andrew Bayer <andrew.bayer@gmail.com>