### PR TITLE
fix: assume jxui basic auth by default

### DIFF
--- a/test/suite/jxui/jxui.go
+++ b/test/suite/jxui/jxui.go
@@ -134,9 +134,7 @@ func (t *AppTestOptions) UITest() bool {
 					if err != nil {
 						return err
 					}
-					if helpers.UseBasicAuthWithUI == "true" {
-						req.SetBasicAuth("admin", helpers.JenkinsBasicAuthPassword)
-					}
+					req.SetBasicAuth("admin", helpers.JenkinsBasicAuthPassword)
 					resp, err := http.DefaultClient.Do(req)
 					if err != nil {
 						return err


### PR DESCRIPTION
Now that JXUI is basic auth secured by default we need to provide the credentials while accessing it during tests by default.
Otherwise all builds that don't explicitly set `JX_APP_UI_TEST_BASIC_AUTH=true` will fail.

cc @romainverduci 