### PR TITLE
fix: remove useless function call

### DIFF
--- a/test/suite/quickstart/helpers.go
+++ b/test/suite/quickstart/helpers.go
@@ -38,14 +38,9 @@ func AllQuickstartsTest() []bool {
 	}
 	tests := make([]bool, 0)
 	for _, testQuickstartName := range IncludedQuickstarts {
-		tests = append(tests, CreateQuickstartsTests(testQuickstartName))
+		tests = append(tests, createQuickstartTests(testQuickstartName))
 	}
 	return tests
-}
-
-//CreateQuickstartsTests creates a batch quickstart test for the given quickstart
-func CreateQuickstartsTests(quickstartName string) bool {
-	return createQuickstartTests(quickstartName)
 }
 
 // CreateQuickstartTest Creates quickstart tests.


### PR DESCRIPTION
We exported a function when it's not used outside of the file it's in and all it did was call another a function to execute the quickstart tests. This commit removes that function.